### PR TITLE
Fix odd edge-case where `isLive` is not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,7 +414,12 @@ function endpointController(endpoint) {
 	if (endpoint.isHealthcheckFor && endpoint.isHealthcheckFor.system && endpoint.isHealthcheckFor.system[0].dataItemID) {
 		endpoint.systemCode = endpoint.isHealthcheckFor.system[0].dataItemID;
 	}
-	endpoint.isLive = (endpoint.isLive.toLowerCase() == "true"); // any case will trigger checkbox for true
+	if (endpoint.isLive && typeof endpoint.isLive === 'string') {
+		// any case will trigger checkbox for true
+		endpoint.isLive = (endpoint.isLive.toLowerCase() == "true");
+	} else {
+		endpoint.isLive = Boolean(endpoint.isLive);
+	}
 	return endpoint;
 }
 


### PR DESCRIPTION
I'm currently seeing an error where an endpoint's `isLive` property is
not a string, and so does not have a `toLowerCase` method.

Example of this breaking:
https://endpointmanager.in.ft.com/manage/origami-bower-registry-eu.herokuapp.com